### PR TITLE
Add plausible-analytics integration

### DIFF
--- a/src/components/HeadTags.astro
+++ b/src/components/HeadTags.astro
@@ -1,8 +1,21 @@
+---
+const plausibleDomain = import.meta.env.PLAUSIBLE_DOMAIN;
+const plausibleScriptURL = import.meta.env.PLAUSIBLE_SCRIPT_URL || 'https://plausible.io/js/script.js';
+---
+
 <slot name="title" />
 <slot name="links" />
 <slot name="meta" />
 
 <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+
+{plausibleDomain && (
+  <script
+    defer
+    data-domain={plausibleDomain}
+    src={plausibleScriptURL}
+  ></script>
+)}
 
 <style>
   /* Rails path links styling */


### PR DESCRIPTION
To make it work locally, point `PLAUSIBLE_SCRIPT_URL` to your local installation's script URL (e.g. `https://plausible.localhost/js/script.local.js`) and set `PLAUSIBLE_DOMAIN` to your domain.

<img width="1229" height="1327" alt="image" src="https://github.com/user-attachments/assets/26b44e7e-1dac-471e-93f4-4a1c91870d68" />
